### PR TITLE
fix: removed @property from _chainstorage

### DIFF
--- a/naeural_core/business/base/base_plugin_biz_api.py
+++ b/naeural_core/business/base/base_plugin_biz_api.py
@@ -242,7 +242,8 @@ class _BasePluginAPIMixin:
     return value
   
   
-  @property
+  # @property
+  # This CANNOT be a property, as it can be a blocking operation.
   def _chainstorage(self): # TODO: hide/move/protect this
     self.__maybe_wait_for_chain_state_init()
     return self.plugins_shmem.get('__chain_storage')

--- a/naeural_core/main/ver.py
+++ b/naeural_core/main/ver.py
@@ -1,4 +1,4 @@
-__VER__ = '7.3.6'
+__VER__ = '7.3.7'
 
 if __name__ == "__main__":
   with open("pyproject.toml", "rt") as fd:


### PR DESCRIPTION
- it triggered a blocking process when searching through class members for endpoint initializing in fastapi plugins