### PR TITLE
fix: fixed value of template NET_MON_01 `SUPERVISOR` value

### DIFF
--- a/extensions/business/xperimental/network_listener_debug.py
+++ b/extensions/business/xperimental/network_listener_debug.py
@@ -1,0 +1,39 @@
+from naeural_core.business.base.network_processor import NetworkProcessorPlugin
+
+_CONFIG = {
+  **NetworkProcessorPlugin.CONFIG,
+
+  'NUMBER_OF_PAYLOADS': 5,
+  'PAYLOAD_PERIOD': 5,
+
+  'VALIDATION_RULES' : {
+    **NetworkProcessorPlugin.CONFIG['VALIDATION_RULES'],
+  },
+}
+
+
+class NetworkListenerDebugPlugin(NetworkProcessorPlugin):
+  _CONFIG = _CONFIG
+  def get_payload_dict(self):
+    return {
+      'AA_network_debug_counter': self.total_payload_count,
+      'AA_network_debug_sender': self.ee_id,
+      'AA_network_debug_sender_full': '|'.join([self.ee_id, self._stream_id, self.get_instance_id()]),
+      'AA_network_debug_path': (self.ee_id, self.ee_addr, self._stream_id, self.get_instance_id())
+    }
+
+  @NetworkProcessorPlugin.payload_handler
+  def on_payload_debug(self, data: dict):
+    payload_number = data.get('AA_network_debug_counter', -1)
+    payload_sender = data.get('AA_network_debug_sender', 'unknown')
+    payload_sender_full = data.get('AA_network_debug_sender_full', 'unknown')
+    self.P(f'Payload number {payload_number} received from {payload_sender_full}.')
+    return
+
+  def process(self):
+    if self.time() - self.last_payload_time > self.cfg_payload_period:
+      for i in range(self.cfg_number_of_payloads):
+        self.add_payload_by_fields(**self.get_payload_dict())
+      # endfor each payload
+    # endif time to add payloads
+    return

--- a/naeural_core/constants.py
+++ b/naeural_core/constants.py
@@ -1,3 +1,6 @@
+# TODO: review if this is safe
+from os import environ
+
 from naeural_client.const import (
   PAYLOAD_CT,
   COMMANDS,
@@ -123,7 +126,7 @@ ADMIN_PIPELINE = {
 
   "NET_MON_01": {
     "PROCESS_DELAY": 20,
-    "SUPERVISOR": False
+    "SUPERVISOR": environ.get("EE_SUPERVISOR", False)
   },
   
 

--- a/naeural_core/main/orchestrator_mixins/utils.py
+++ b/naeural_core/main/orchestrator_mixins/utils.py
@@ -20,7 +20,7 @@ class _OrchestratorUtils(object):
         return_tree=True,
       )
     except:
-      mem2, tree2, top2  = 0, 0, 0
+      mem2, tree2, top2  = 0, 0, []
       self.P(" * * * * * * * * * * * * ERROR: get_obj_size FAILED !  * * * * * * * * * * * *\n{}".format(
         traceback.format_exc()
       ))

--- a/naeural_core/main/ver.py
+++ b/naeural_core/main/ver.py
@@ -1,4 +1,4 @@
-__VER__ = '7.3.13'
+__VER__ = '7.3.14'
 
 if __name__ == "__main__":
   with open("pyproject.toml", "rt") as fd:


### PR DESCRIPTION
- used os.environ in case the `EE_SUPERVISOR` does not exist in the .env file